### PR TITLE
Incorrect Return type fix in pk3.cpp

### DIFF
--- a/engine/src/pk3.cpp
+++ b/engine/src/pk3.cpp
@@ -356,7 +356,7 @@ char* CPK3::ExtractFile( const char *lpname, int *file_size )
     }
     //if the file isn't in the archive
     if (index == -1)
-        return false;
+        return 0; //changed from false as it cannot convert bool to char*
     int flength = GetFileLen( index );
 
     buffer = new char[flength];


### PR DESCRIPTION
Modified an incorrect return type in pk3.cpp line 359, it was returning "false" at the time, but the compiler was having difficulties converting bool to char*. Thus, I switched it out for 0, basically what 'false' normally is. I'm unsure whether this will cause issues elsewhere but it appears to be fixed for now.