### PR TITLE
Bool to VS* type Compilation error fix

### DIFF
--- a/engine/src/gfx/cockpit_xml.cpp
+++ b/engine/src/gfx/cockpit_xml.cpp
@@ -315,7 +315,7 @@ void GameCockpit::beginElement( const string &name, const AttributeList &attribu
         for (counter = 0; counter < 4; ++counter)
             if (!replaced[counter]) {
                 delete Pit[counter];
-                Pit[counter] = false;
+                Pit[counter] = 0;
             }
         break;
     case UnitImages< void >::SHIELD4:


### PR DESCRIPTION
Adjusting a bool to VS* type to a 0 to VS* instead, which seems to have fixed the error expecting it to be buggy however.