### PR TITLE
Extending the Copysign fix

### DIFF
--- a/engine/src/cmd/unit_generic.cpp
+++ b/engine/src/cmd/unit_generic.cpp
@@ -52,6 +52,17 @@
 #include <iostream>
 #define DEBUG_MESH_ANI
 
+namespace vsphysics
+{
+	float copysign( float x, float y )
+	{
+		if (y > 0)
+			return x;
+		else
+			return -x;
+	}
+}
+
 //cannot seem to get min and max working properly across win and lin any other way...
 static float mymax( float a, float b )
 {
@@ -630,16 +641,7 @@ void Unit::DeactivateJumpDrive()
         jump.drive = -1;
 }
 
-namespace vsphysics
-{
-	float copysign( float x, float y )
-	{
-		if (y > 0)
-			return x;
-		else
-			return -x;
-	}
-}
+
 
 float rand01()
 {

--- a/engine/src/cmd/unit_generic.h
+++ b/engine/src/cmd/unit_generic.h
@@ -64,6 +64,7 @@ void UncheckUnit( class Unit*un );
 extern char * GetUnitDir( const char *filename );
 extern float capship_size;
 
+
 //A stupid struct that is only for grouping 2 different types of variables together in one return value
 class CargoColor
 {

--- a/engine/src/cmd/unit_physics.h
+++ b/engine/src/cmd/unit_physics.h
@@ -41,7 +41,16 @@
 #include "networking/lowlevel/vsnet_clientstate.h"
 #include "networking/netclient.h"
 
-extern float copysign( float x, float y );
+namespace vsphysics
+{
+	float copysign( float x, float y )
+	{
+		if (y > 0)
+			return x;
+		else
+			return -x;
+	}
+}
 
 extern unsigned int apply_float_to_unsigned_int( float tmp ); //short fix
 


### PR DESCRIPTION
; Namespace put in multiple files could probably be better implemented in a write once include thing. This simply gets around the cmath overloading function conflict. 