### PR TITLE
Hashtable missing

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -324,7 +324,6 @@ SET(LIBROOTGENERIC_SOURCES src/configxml.cpp
 						   src/galaxy_gen.cpp
 						   src/galaxy_xml.cpp
 						   src/galaxy.cpp
-						   src/hashtable.cpp
 						   src/lin_time.cpp
 						   src/load_mission.cpp
 						   src/pk3.cpp 

--- a/engine/objconv/CMakeLists.txt
+++ b/engine/objconv/CMakeLists.txt
@@ -42,7 +42,6 @@ SET(MESHER_SOURCES mesher/Converter.cpp
                    mesher/Modules/XMesh_to_BFXM.cpp
                    mesher/Modules/XMesh_to_Ogre.cpp
                    mesher/Modules/Wavefront_to_BFXM.cpp
-                   ${vsUTCS_SOURCE_DIR}/src/hashtable.cpp
                    ${vsUTCS_SOURCE_DIR}/src/xml_support.cpp)
 
 include_directories(${MSH_INCLUDES} mesher)


### PR DESCRIPTION
Cmake yields an error in experimental due to missing file, this is a fix to get that solved. 